### PR TITLE
update presentation tool resolver to new format

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           body: I ran `npm run format` 🧑‍💻
           branch: actions/prettier
-          commit-message: 'chore(prettier): 🤖 ✨'
+          commit-message: "chore(prettier): 🤖 ✨"
           labels: 🤖 bot
           sign-commits: true
-          title: 'chore(prettier): 🤖 ✨'
+          title: "chore(prettier): 🤖 ✨"
           token: ${{ steps.generate-token.outputs.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # misc
 .DS_Store
 *.pem
+.idea
 
 # debug
 npm-debug.log*

--- a/package-lock.json
+++ b/package-lock.json
@@ -7063,7 +7063,7 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -23100,7 +23100,7 @@
       "dependencies": {
         "@sanity/vision": "3.87.1",
         "react": "19.2.1",
-        "react-dom": "19.0.0",
+        "react-dom": "19.2.1",
         "rxjs": "7.8.1",
         "sanity": "3.87.1",
         "styled-components": "6.1.15"
@@ -23133,21 +23133,21 @@
       }
     },
     "studio/node_modules/react-dom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
+      "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.25.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.0.0"
+        "react": "^19.2.1"
       }
     },
     "studio/node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     }
   }

--- a/remix-app/app/root.tsx
+++ b/remix-app/app/root.tsx
@@ -86,7 +86,7 @@ export default function App() {
             __html: `window.ENV = ${JSON.stringify(ENV)}`,
           }}
         />
-        {ENV.SANITY_STUDIO_STEGA_ENABLED ? (
+        {ENV.SANITY_STUDIO_STEGA_ENABLED === 'true' ? (
           <Suspense>
             <LiveVisualEditing />
           </Suspense>

--- a/remix-app/app/sanity/projectDetails.ts
+++ b/remix-app/app/sanity/projectDetails.ts
@@ -24,4 +24,4 @@ export const stegaEnabled = SANITY_STUDIO_STEGA_ENABLED === 'true'
 if (!projectId) throw new Error('Missing SANITY_STUDIO_PROJECT_ID in .env')
 if (!dataset) throw new Error('Missing SANITY_STUDIO_DATASET in .env')
 if (!studioUrl) throw new Error('Missing SANITY_STUDIO_URL in .env')
-if (!stegaEnabled) throw new Error(`Missing SANITY_STUDIO_STEGA_ENABLED in .env`)
+if (stegaEnabled === undefined) throw new Error(`Missing SANITY_STUDIO_STEGA_ENABLED in .env`)

--- a/remix-app/package.json
+++ b/remix-app/package.json
@@ -9,7 +9,7 @@
     "dev": "remix dev",
     "generate:css": "postcss ./app/styles --dir ./app/styles/build",
     "start": "remix-serve build/index.js",
-    "typecheck": "tsc"
+    "typecheck": "tsc --skipLibCheck"
   },
   "dependencies": {
     "@portabletext/react": "3.2.1",

--- a/remix-app/package.json
+++ b/remix-app/package.json
@@ -8,7 +8,7 @@
     "build": "remix build",
     "dev": "remix dev",
     "generate:css": "postcss ./app/styles --dir ./app/styles/build",
-    "start": "remix-serve build",
+    "start": "remix-serve build/index.js",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -2,46 +2,10 @@ import {visionTool} from '@sanity/vision'
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {schemaTypes} from './schemas'
-import {presentationTool, DocumentLocationResolver} from 'sanity/presentation'
-import {Observable, map} from 'rxjs'
+import {defineDocuments, defineLocations, presentationTool} from 'sanity/presentation'
 
 export const projectId = process.env.SANITY_STUDIO_PROJECT_ID!
 export const dataset = process.env.SANITY_STUDIO_DATASET!
-
-const locate: DocumentLocationResolver = (params, context) => {
-  const {documentStore} = context
-
-  if (params.type === 'post') {
-    // Listen to the query and fetch the draft and published document
-    const doc$ = documentStore.listenQuery(`*[_id == $id][0]{slug,title}`, params, {
-      perspective: 'drafts',
-    }) as Observable<{
-      slug: {current: string | null} | null
-      title: string | null
-    } | null>
-
-    return doc$.pipe(
-      map((doc) => {
-        if (!doc || !doc.slug?.current) return null
-
-        return {
-          locations: [
-            {
-              title: doc.title || 'Untitled',
-              href: `/post/${doc.slug.current}`,
-            },
-            {
-              title: 'Posts',
-              href: `/`,
-            },
-          ],
-        }
-      }),
-    )
-  }
-
-  return null
-}
 
 export default defineConfig({
   name: 'project-name',
@@ -52,7 +16,25 @@ export default defineConfig({
     structureTool(),
     presentationTool({
       previewUrl: process.env.SANITY_STUDIO_PREVIEW_URL || 'http://localhost:3000',
-      locate,
+      resolve: {
+        mainDocuments: defineDocuments([
+          {
+            route: '/post/:slug',
+            filter: `_type == "post" && slug.current == $slug`,
+          },
+        ]),
+        locations: {
+          post: defineLocations({
+            select: {title: 'title', slug: 'slug.current'},
+            resolve: (doc) => ({
+              locations: [
+                {title: doc?.title, href: `/post/${doc?.slug}`},
+                {title: 'My Remix Sanity Homepage', href: `/`},
+              ],
+            }),
+          }),
+        },
+      },
     }),
     visionTool(),
   ],


### PR DESCRIPTION
### Description

I ran into an issue with the location resolver trying to pull down and run this project fresh. I've updated the location resolver in a way I think is more copacetic with the current "way of doing things" - but totally new to sanity so doublecheck me! 

Before
<img width="2946" height="1740" alt="image" src="https://github.com/user-attachments/assets/60280d0c-8388-4d7f-8b21-65afeb9d4cbf" />

After
<img width="2980" height="1760" alt="image" src="https://github.com/user-attachments/assets/7dc5a728-05bf-4be2-9cdf-217bb38c9aa7" />


I also ran prettier locally which caught a few extra things, as well as a few updates to package-lock

### What to review

Ensure the changes meet sanity standards

### Testing

Locally I verified that the location resolver is populating two places - 
1. Clicking around in the Presentation tab finds the right documents
2. From the Structure/document - you can now see the usages populated correctly.


